### PR TITLE
Documentación de mentorización

### DIFF
--- a/mentorias/index.md
+++ b/mentorias/index.md
@@ -1,0 +1,68 @@
+# Mentorías WordPress
+
+A principios de 2023, el Equipo de Comunidad global planteó unas mentorías para cualquier persona de la Comunidad WordPress.
+
+- [Proposal: Creating a WordPress Contributor Mentorship Program](https://make.wordpress.org/project/2023/02/06/proposal-creating-a-wordpress-contributor-mentorship-program/) _(en inglés)_
+- [Launching the Contributor Working Group: Call for Volunteers](https://make.wordpress.org/community/2023/03/10/launching-the-contributor-working-group-call-for-volunteers/) _(en inglés)_
+- [WordPress Contributor Mentorship Program: Pilot Program Proposal](https://make.wordpress.org/project/2023/05/17/wordpress-contributor-mentorship-program-pilot-program-proposal/) _(en inglés)_
+- [WordPress Contributor Mentorship Program: White Paper](https://docs.google.com/document/d/16OijTz3lXOv6b-N0Odt_bU51EJhArvg5wep_B04cs-U/) _(en inglés)_
+
+## ¿Qué es el Programa de Mentorización?
+
+El Programa de Mentorización de Contribuidores de la COmunidad WordPress tiene como objetivo proporcionar mentores individuales, y de grupo, a contribuidores nuevos o aspirantes. El programa pretende ser una vía para ayudar a los nuevos contribuidores a encontrar su camino en las contribuciones a WordPress.
+
+Su objetivo es preparar a los nuevos contribuidores para el éxito, proporcionándoles la orientación, las habilidades y los conocimientos necesarios sobre el proyecto y ayudándoles a realizar sus primeras contribuciones.
+
+En su forma ideal, el programa:
+
+- Ayudará e inspirará a sus participantes a realizar contribuciones continuas al proyecto WordPress.
+- Explicará a los participantes las distintas áreas de contribución del proyecto WordPress.
+- Ayudará a los participantes a seleccionar con éxito su área de participación en el proyecto WordPress.
+- Proporcionará la orientación necesaria y las conexiones con la Comunidad que ayudarán a los participantes a tener éxito con sus contribuciones.
+- Ayudará a los participantes a encontrar el éxito en su carrera profesional a través de contribuciones exitosas al código abierto.
+
+## Ya he acabado la mentorización global
+
+Si ya has acabado el Programa de Mentorización global, ahora es el momento de ver las diferencias y elenentos complementarios de la Comunidad WordPress de España.
+
+La Comunidad WordPress de España es una de las más activas del mundo, y dispone de algunas herramientas e idiosincrasia propia. Y aquí vamos a listarte todo lo que necesitas para entenderla.
+
+### Comunicación
+
+La Comunidad WordPress global se comunica a través del Slack en la dirección [wordpress.slack.com](https://wordpress.slack.com/) ([acceso](https://wordpress.slack.com/signin) y [registro](https://wordpress.slack.com/signup)).
+
+En el caso de la Comunidad WordPress de España, también dispone de una dirección de Slack, que se encuentra en [wpes.slack.com](https://wpes.slack.com/) ([acceso](https://wpes.slack.com/signin) y [registro](https://wpes.slack.com/signup)). Tienes [instrucciones de cómo conectarte al Slack de WordPress España](https://es.wordpress.org/guias/chat/), aunque el sistema está configurado como en global, para poder acceder con tu cuenta de correo de usuario de WordPress _usuario@chat.wordpress.org_.
+
+### Equipos y representantes
+
+En la Comunidad WordPress de España no tenemos tantos equipos como en la Comunidad global, y en algunos casos hay algunas diferencias o se centran en proyectos concretos.
+
+| Equipo | URL global | URL España | Canal Slack | Representantes |
+|---|---|---|---|---|
+| Accesibilidad | [enlace](https://make.wordpress.org/accessibility/) | [enlace](https://es.wordpress.org/colabora/accesibilidad/) | [#accesibilidad](https://wpes.slack.com/archives/C03E5S46P) | @visanju |
+| Comunidad | [enlace](https://make.wordpress.org/community/) | [enlace](https://es.wordpress.org/colabora/comunidad/) | [#meetups](https://wpes.slack.com/archives/C03DCM27G) [#wordcamps](https://wpes.slack.com/archives/C03DCM392) | @_dorsvenabili |
+| Diseño | [enlace](https://make.wordpress.org/design/) | [enlace](https://es.wordpress.org/colabora/diseno/) | [#diseño](https://wpes.slack.com/archives/CAF724L03) | @acirujano |
+| Diversidad |  |  | [#diversidad](https://wpes.slack.com/archives/C056GU1HTCL) |  |
+| Documentación | [enlace](https://make.wordpress.org/docs/) |  | [#docs](https://wpes.slack.com/archives/C7SP11LQP) | @javiercasares |
+| Hosting | [enlace](https://make.wordpress.org/hosting/) |  | [#hosting](https://wpes.slack.com/archives/CGQF8PZ7T) [#seguridad](https://wpes.slack.com/archives/C2204GTBJ) | @javiercasares |
+| Marketing | [enlace](https://make.wordpress.org/marketing/) | [enlace](https://es.wordpress.org/colabora/marketing/) | [#marketing](https://wpes.slack.com/archives/C2MA1HA20) | @anagavilan |
+| Soporte | [enlace](https://make.wordpress.org/support/) | [enlace](https://es.wordpress.org/colabora/soporte/) |  | @josearcos, @fernandot |
+| Sostenibilidad | [enlace](https://make.wordpress.org/sustainability/) |  |  |  |
+| Traducciones | [enlace](https://make.wordpress.org/polyglots/) | [enlace](https://es.wordpress.org/colabora/traducciones/) | [#traducciones](https://wpes.slack.com/archives/C03DANZSC) | [General Translation Editors](https://make.wordpress.org/polyglots/teams/?locale=es_ES) |
+| TV | [enlace](https://make.wordpress.org/tv/) | [enlace](https://es.wordpress.org/colabora/tv/) |  | @pablo-moratinos |
+
+## Traducciones
+
+Uno de los equipos más activos de la Comunidad WordPress de España es el de traducciones. A diferencia de otros sistemas, la mayoría de la comunicación se hace a través del Slack, por lo que si alguien aprueba cadenas o necesita ayuda, se comunica e invita a que se haga a través de este espacio, aunque no es obligatorio.
+
+## Marketing y Comunicación
+
+Otro de los equipos muy activos de la Comunidad WordPress de España es el de Marketing y Comunicación. Este equipo tiene dos misiones principales.
+
+Una de ellas es la de dar soporte a las Comunidades WordPress Locales (Meetup) y a las WordCamp en todo lo que tiene que ver con la Comunicación, tanto dentro de sus sitios web, dentro de Meetup.com o a través de las redes sociales.
+
+En redes sociales, la Comunidad tiene varias cuentas:
+
+- Linkedin: [WordPress España](https://www.linkedin.com/company/wordpress-espa%C3%B1a/)
+- Twitter: [@wp_es](https://twitter.com/wp_es/)
+


### PR DESCRIPTION
Esta es una primera versión y acercamiento al Proyecto de Mentorización global.

El objetivo es mostrar las principales diferencias entre la Comunidad global y la Comunidad de España para aquellos que ya hayan pasado su mentorización global, y puedan entender y complementar con los elementos y herramientas de uso en la Comunidad de España.

Es una primera versión y acercamiento que deberá ser complementada con los responsables de cada equipo y por la Comunidad en general.