### PR TITLE
Glycymeris reorganizacion index manual GitHub

### DIFF
--- a/manuales/github/commit/index.md
+++ b/manuales/github/commit/index.md
@@ -1,0 +1,2 @@
+# Crear una instantánea de los cambios realizados en un documento
+

--- a/manuales/github/comofunciona/index.md
+++ b/manuales/github/comofunciona/index.md
@@ -8,15 +8,15 @@ Si ya tienes una cuenta, puedes continuar en este camino.
 
 ## Qué es un repositorio
 
-Llamamos repositorio a un lugar, que se podría comparar con una unidad de disco duro o una carpeta principal de un servidor, en definitiva, un lugar de almacenamiento de archivos.
+Llamamos _repositorio_ a un lugar, que se podría comparar con una unidad de disco duro o una carpeta principal de un servidor, en definitiva, un lugar de almacenamiento de archivos.
 
-En este repositorio se pueden almacenar todo tipo de archivos, desde carpetas y ficheros sin un orden concreto, un programa completo o un manual como el que estás leyendo ahora mismo, que fue escrito en GitHub antes de ser publicado en la web.
+En este _repositorio_ se pueden almacenar todo tipo de archivos, desde carpetas y ficheros sin un orden concreto, un programa completo o un manual como el que estás leyendo ahora mismo, que fue escrito en GitHub antes de ser publicado en la web.
 
 ## Acceder al repositorio de WordPress España
 
 Para acceder al repositorio de WordPress, no tienes más que acceder a través de la siguiente dirección:
 
-[https://github.com/WPES/spain-handbook/](https://github.com/WPES/spain-handbook)
+[https://github.com/WordPress/spain-handbook](https://github.com/WordPress/spain-handbook)
 
 En este repositorio están alojados todos los archivos que conforman todo el manual de WordPress en español.
 
@@ -24,7 +24,7 @@ Aquí es donde vas a hacer todos los cambios que, una vez aceptados, se reflejar
 
 Una vez registrados podemos acceder a la página principal de [GitHub](https://github.com/) y en la barra lateral aparecerá el listado de repositorios a los que tenemos acceso.
 
-Pinchamos en [WPES/spain-handbook](https://github.com/WPES/spain-handbook) para acceder al repositorio de manuales de WordPress España. En la parte superior izquierda podremos ver en todo momento en qué repositorio estamos.
+Pinchamos en [WordPress/spain-handbook](https://github.com/WordPress/spain-handbook) para acceder al repositorio de manuales de WordPress España. En la parte superior izquierda podremos ver en todo momento en qué repositorio estamos.
 
 Con el fin de evitar posibles errores o conflictos **es importante no trabajar nunca directamente en este repositorio principal**. Para poder editar con seguridad, crearemos una copia del repositorio principal (*fork*) que será donde trabajaremos.
 
@@ -34,7 +34,7 @@ Crearemos el *fork* pinchando en el último botón que aparece en la parte super
 
 ![Realización Fork](https://raw.githubusercontent.com/WPES/spain-handbook/master/manuales/github/assets/ForkCuentaPrincipal.png)
 
-Después de realizarlo, la ventana cambiará y si nos fijamos en la ruta que se muestra en la parte de arriba a la izquierda ya aparecerá nuestro nombre de usuario, desde este momento cualquier cambio que hagamos en este repositorio, no afectará al repositorio original hasta que no hagamos un *Pull request* y éste no sea verificado y aprobado.
+Después de realizarlo, la ventana cambiará y si nos fijamos en la ruta que se muestra en la parte de arriba a la izquierda ya aparecerá nuestro nombre de usuario, desde este momento cualquier cambio que hagamos en este repositorio, no afectará al repositorio original hasta que no hagamos un *Pull request* (solicitud de revisión) y éste no sea verificado y aprobado.
 
 ![Fork realizado](https://raw.githubusercontent.com/WPES/spain-handbook/master/manuales/github/assets/ForkRealizado.PNG)
 
@@ -44,9 +44,13 @@ Después de realizarlo, la ventana cambiará y si nos fijamos en la ruta que se 
 
 **Si nuestro *fork* deja de estar actualizado**
 
-Cuando se trabaja en un _fork_, se trabaja paralelamente al archivo máster. Es decir, los cambios producidos en el archivo principal (_master_) no se sincronizan automáticamente con nuestro _fork_.
+Cuando se trabaja en un _fork_, se trabaja paralelamente al repositorio principal (wordpress/spain-handbook) en tu cuenta de github (micuenta/spain-handbook). 
 
-GitHub nos lo indicará con la siguiente frase: `This branch is 8 commits behind WPES:master`
+Por tanto es posible que, mientras estés trabajando, otros contribuidores estén haciendo lo mismo en sus respectivos forks y hayan mandado los cambios al repositorio principal. Esos cambios no se aplicarán en tu fork mientras no sincronices tu repositorio con el principal.
+
+De hecho, verás un mensaje como el siguiente:
+
+`This branch is 8 commits behind WPES:master`
 
 Significa que se han realizado 8 modificaciones desde que hicimos nuestra copia (*fork*).
 

--- a/manuales/github/editardocumento/index.md
+++ b/manuales/github/editardocumento/index.md
@@ -1,0 +1,9 @@
+# Editar un documento/archivo
+
+Nota para el editor:
+
+Aquí se va a explicar cómo se edita un fichero de texto (darle al lapiz y empezar a escribir).
+
+Enlazar el manual de Markdown
+
+Enlazar el manual de edición de imágenes

--- a/manuales/github/fetch/index.md
+++ b/manuales/github/fetch/index.md
@@ -1,0 +1,5 @@
+# Sincronizar tu fork desde el repositorio principal (fetch)
+
+Nota para el editor:
+
+Esta paso se tiene que hacer siempre que se empieza a trabajar y cada vez que se van a mandar los cambios, antes de enviarlos.

--- a/manuales/github/fork/index.md
+++ b/manuales/github/fork/index.md
@@ -1,0 +1,3 @@
+# Crear una copia (fork) del repositorio principal del manual de WordPress en Español a tu cuenta de GitHub
+
+Nota para el editor: Aclarar que la documentación está alojada en el repositorio principal de WordPress (wordpress/spain-handbook), y que tu fork (tucuentagithub/spain-handbook) es donde se realizarán los pequeños cambios para ser enviados luego a revisión, antes de integrarlos en el repositorio principal.

--- a/manuales/github/index.md
+++ b/manuales/github/index.md
@@ -34,6 +34,6 @@ En este manual te explicamos cómo puedes acceder a esta herramienta, su funcion
 
 - [Crear una cuenta en GitHub](https://es.wordpress.org/team/handbook/manuales/github/crear/)
 - [Enlazar tu perfil de WordPress con GitHub](https://es.wordpress.org/team/handbook/manuales/wordpress/sincronizar/)
-- Trabajar en el repositorio
+- [Trabajar en el repositorio spain-handbook en GitHub](https://es.wordpress.org/team/handbook/manuales/github/comofunciona/)
 - Editar un documento/archivo
 - Solicitar la revisión y aceptación de los cambios

--- a/manuales/github/index.md
+++ b/manuales/github/index.md
@@ -22,9 +22,9 @@ No obstante, en Github también se puede trabajar con documentos de texto con fo
 
 ### Diferencias entre Git y GitHub
 
-Si has leído los dos apartados anteriores, puedes concluir que Git es un sistema de control de versiones que se instala en el sistema operativo de nuestro ordenador o de un servidor.
+Si has leído los dos apartados anteriores, puedes concluir que **Git** es un sistema de control de versiones que se instala en el sistema operativo de nuestro ordenador o de un servidor.
 
-Por el contrario, Github es una plataforma colaborativa con funciones de red social, basada en Git, que permite llevar, además del control de versiones de un proyecto, la gestión del propio proyecto, de los tickets con propuestas que van surgiendo durante el proyecto, y de las propuestas de cambio realizadas por los colaboradores.
+Por el contrario, **Github** es una plataforma colaborativa con funciones de red social, basada en Git, que permite llevar, además del control de versiones de un proyecto, la gestión del propio proyecto, de los tickets con propuestas que van surgiendo durante el proyecto, y de las propuestas de cambio realizadas por los colaboradores.
 
 ## Cómo colaborar en el manual de WordPress España con GitHub
 
@@ -32,8 +32,18 @@ Para colaborar en el manual de WordPress España, cualquier contribuidor que qui
 
 En este manual te explicamos cómo puedes acceder a esta herramienta, su funcionamiento y todo lo que tienes que conocer para colaborar en el proyecto de la forma más fácil posible. Sigue los siguientes pasos, si alguno ya lo has hecho previamente, puedes saltártelo:
 
-- [Crear una cuenta en GitHub](https://es.wordpress.org/team/handbook/manuales/github/crear/)
-- [Enlazar tu perfil de WordPress con GitHub](https://es.wordpress.org/team/handbook/manuales/wordpress/sincronizar/)
+- _Paso 1_: [Crear una cuenta en GitHub](https://es.wordpress.org/team/handbook/manuales/github/crear/)
+- _Paso 2_: [Enlazar tu perfil de WordPress con GitHub](https://es.wordpress.org/team/handbook/manuales/wordpress/sincronizar/)
+- _Paso 3_: [Crear una copia (fork) del repositorio principal del manual de WordPress en Español a tu cuenta de GitHub](https://es.wordpress.org/team/handbook/manuales/github/fork/)
+- _Paso 4_: [Revisar los issues (tareas)](https://es.wordpress.org/team/handbook/manuales/github/issues/)
+- _Paso 5_: [Crear una rama en tu fork](https://es.wordpress.org/team/handbook/manuales/github/rama/)
+- _Paso 6_: [Sincronizar tu fork desde el repositorio principal (fetch)](https://es.wordpress.org/team/handbook/manuales/github/fetch/)
+- _Paso 7_: [Editar un documento/archivo](https://es.wordpress.org/team/handbook/manuales/github/editardocumento/)
+- _Paso 8_: [Crear una instantánea de los cambios realizados (commit)](https://es.wordpress.org/team/handbook/manuales/github/commit/)
+- _Paso 9_: [Solicitar revisión de los cambios (Pull Request o PR)](https://es.wordpress.org/team/handbook/manuales/github/pullrequest/)
+
+
+NOTA: ELIMINAR LOS SIGUIENTES ENLACES, CARPETAS Y ARCHIVOS CUANDO SE HAYAN CREADO LOS ANTERIORES
 - [Trabajar en el repositorio spain-handbook en GitHub](https://es.wordpress.org/team/handbook/manuales/github/comofunciona/)
 - Editar un documento/archivo
 - Solicitar la revisión y aceptación de los cambios

--- a/manuales/github/issues/index.md
+++ b/manuales/github/issues/index.md
@@ -1,0 +1,11 @@
+# Revisar los issues (tareas)
+
+Notas para los editores:
+
+Los Issues siempre se deben consultar y crear en el repositorio principal (wordpress/spain-handbook).
+
+Dos casos:
+- Quiero notificar un error
+- Quiero contribuir
+
+Para pedir que te lo atribuyan hay que dejar un comentario en el issue.

--- a/manuales/github/pullrequest/index.md
+++ b/manuales/github/pullrequest/index.md
@@ -1,0 +1,9 @@
+# Solicitar revisión de los cambios realizados (Pull Request o PR)
+
+Nota para el editor:
+
+Explicar que al final hay que esperar a que un administrador lo revise. Pueden pasar 3 cosas:
+
+- Aceptado
+- Rechazado
+- Solicitud de cambios -> Se hacen en la misma rama

--- a/manuales/github/rama/index.md
+++ b/manuales/github/rama/index.md
@@ -1,0 +1,13 @@
+# Crear una rama en tu fork
+
+Notas para el editor:
+
+Una vez que has elegido el issue, crea una rama en tu fork
+
+la rama debe tener el formato
+
+nombre_usuario_wordpress-nombre_asociado_al_issue
+
+Ejemplo:
+
+glycymeris-crear-estructura-archivos-manual-github


### PR DESCRIPTION
He reorganizado completamente el index.md del manual de github y he creado la nueva estructura por pasos del flujo de trabajo. Estos pasos son:

- [x] _Paso 1_: [Crear una cuenta en GitHub](https://es.wordpress.org/team/handbook/manuales/github/crear/)
- [x] _Paso 2_: [Enlazar tu perfil de WordPress con GitHub](https://es.wordpress.org/team/handbook/manuales/wordpress/sincronizar/)
- [x] _Paso 3_: [Crear una copia (fork) del repositorio principal del manual de WordPress en Español a tu cuenta de GitHub](https://es.wordpress.org/team/handbook/manuales/github/fork/)
- [x] _Paso 4_: [Revisar los issues (tareas)](https://es.wordpress.org/team/handbook/manuales/github/issues/)
- [x] _Paso 5_: [Crear una rama en tu fork](https://es.wordpress.org/team/handbook/manuales/github/rama/)
- [x] _Paso 6_: [Sincronizar tu fork desde el repositorio principal (fetch)](https://es.wordpress.org/team/handbook/manuales/github/fetch/)
- [x] _Paso 7_: [Editar un documento/archivo](https://es.wordpress.org/team/handbook/manuales/github/editardocumento/)
- [x] _Paso 8_: [Crear una instantánea de los cambios realizados (commit)](https://es.wordpress.org/team/handbook/manuales/github/commit/)
- [x] _Paso 9_: [Solicitar revisión de los cambios (Pull Request o PR)](https://es.wordpress.org/team/handbook/manuales/github/pullrequest/)

Una vez se hayan editado todos estos archivos, se deberá eliminar el archivo ya existente:
- [x] [Trabajar en el repositorio spain-handbook en GitHub](https://es.wordpress.org/team/handbook/manuales/github/comofunciona/)