### PR TITLE
Respuesta insignia

### DIFF
--- a/marketing/wordcamp/preguntas/index.md
+++ b/marketing/wordcamp/preguntas/index.md
@@ -1,0 +1,11 @@
+# Preguntas frecuentes
+
+## La insignia de Ponente no aparece en el perfil de WordPress tras finalizar la WordCamp
+
+Tras mi primera ponencia en Madrid no aparece la insignia de WordCamp Speaker.
+En este caso, la forma correcta de actuar debe ser la siguiente:
+
+- Entrar en la ficha de la WordCamp del ponente.
+- Darle a guardar de nuevo, validando que el nombre de usuario sea el correcto.
+
+Con estos sencillos pasos se queda actualizado el perfil del ponente.

--- a/marketing/wordcamp/preguntas/index.md
+++ b/marketing/wordcamp/preguntas/index.md
@@ -1,11 +1,12 @@
 # Preguntas frecuentes
 
-## La insignia de Ponente no aparece en el perfil de WordPress tras finalizar la WordCamp
+## ¿Como conseguir la insignia de ponente en una WordCamp si ha sido tu primera ponencia?
 
-Tras mi primera ponencia en Madrid no aparece la insignia de WordCamp Speaker.
-En este caso, la forma correcta de actuar debe ser la siguiente:
+Tras realizar un colaborador de WordPress por vez primera una ponencia en una WordCamp, en ocasiones, no aparece la insignia en su perfil de WordPress.org.
+Para que este error del sistema se solvente, se debe realizar la siguientes acciones.
 
-- Entrar en la ficha de la WordCamp del ponente.
-- Darle a guardar de nuevo, validando que el nombre de usuario sea el correcto.
+1. Entrar en la web de la WordCamp donde el colaborador ha realizado la ponencia.
+2. Buscar la ficha del ponente por su nombre y hacer clic en guardar.
+3. Refrescar o actualizar la web.
 
-Con estos sencillos pasos se queda actualizado el perfil del ponente.
+Siguiendo esta sencilla guía, el colaborador obtendrá en su perfil de WordPress.org, de forma automática, la insignia de ponente en WordCamp.

--- a/marketing/wordcamp/preguntas/index.md
+++ b/marketing/wordcamp/preguntas/index.md
@@ -1,12 +1,11 @@
 # Preguntas frecuentes
 
-## ¿Como conseguir la insignia de ponente en una WordCamp si ha sido tu primera ponencia?
+## La insignia de Ponente no aparece en el perfil de WordPress tras finalizar la WordCamp
 
-Tras realizar un colaborador de WordPress por vez primera una ponencia en una WordCamp, en ocasiones, no aparece la insignia en su perfil de WordPress.org.
-Para que este error del sistema se solvente, se debe realizar la siguientes acciones.
+Tras mi primera ponencia en Madrid no aparece la insignia de WordCamp Speaker.
+En este caso, la forma correcta de actuar debe ser la siguiente:
 
-1. Entrar en la web de la WordCamp donde el colaborador ha realizado la ponencia.
-2. Buscar la ficha del ponente por su nombre y hacer clic en guardar.
-3. Refrescar o actualizar la web.
+- Entrar en la ficha de la WordCamp del ponente.
+- Darle a guardar de nuevo, validando que el nombre de usuario sea el correcto.
 
-Siguiendo esta sencilla guía, el colaborador obtendrá en su perfil de WordPress.org, de forma automática, la insignia de ponente en WordCamp.
+Con estos sencillos pasos se queda actualizado el perfil del ponente.


### PR DESCRIPTION
Creada la ruta de respuesta para poder obtener la insignia de ponente tras una WordCamp. He propuesto la creación de una carpeta sobre preguntas frecuentes con la siguiente ruta: marketing/WordCamp/preguntas