### PR TITLE
Celigaroe Handbook eventos sostenibles - correcciones de enlaces

### DIFF
--- a/eventos/sostenibilidad/index.md
+++ b/eventos/sostenibilidad/index.md
@@ -6,7 +6,7 @@ Cada evento de WordPress, sea en persona o en línea, tiene un impacto medioambi
 
 Encontrarás todo lo que necesitas saber para organizar una WordCamp, una [Meetup](https://es.wordpress.org/team/handbook/comunidad/meetup/), o un evento de WordPress presencial o en línea en los manuales de los eventos. Sin embargo, las siguientes sugerencias ayudarán a que tu evento sea más sostenible. 
 
-Este manual también incluye algunos [trucos para asistentes](https://es.wordpress.org/make/handbook/sostenibilidad/eventos/asistentes) que puedes mostrar en la página web de tu evento.
+Este manual también incluye algunos [trucos para asistentes](https://es.wordpress.org/team/handbook/eventos/sostenibilidad/asistentes/) que puedes mostrar en la página web de tu evento.
 
 A continuación puedes ver los consejos para crear un evento de WordPress más sostenible por temáticas: 
 

--- a/eventos/sostenibilidad/regalos/index.md
+++ b/eventos/sostenibilidad/regalos/index.md
@@ -10,7 +10,7 @@ Los regalos de bienvenida son otra historia. Aunque poco necesarios, suelen ser 
   - Opción para la cinta de la acreditación (_lanyard_), invitando a que traigan la suya.
   - Opción para recibir o no taza o botella de regalo.
   - Opción para pedir o no camiseta del evento.
-- Prioriza los artículos promocionales sostenibles para los ponentes. Consulta la sección [Inspiración](https://es.wordpress.org/make/handbook/sostenibilidad/eventos/inspiracion)) para obtener ideas.
+- Prioriza los artículos promocionales sostenibles para los ponentes. Consulta la sección [Inspiración](https://es.wordpress.org/team/handbook/eventos/sostenibilidad/inspiracion/) para obtener ideas.
 - Cuando imprimas artículos promocionales localmente, considera un diseño atemporal: solo incluye el logotipo de WordPress. Esto garantiza que los artículos promocionales sobrantes se puedan usar en otros eventos. Tienes enlaces a los diseños oficiales de WordPress en el [WordCamp Organizer Handbook](https://make.wordpress.org/community/handbook/wordcamp-organizer/planning-details/swag/swag-source-files/) (en inglés).
 
 Planifica qué hacer con los artículos promocionales sobrantes después del evento.

--- a/eventos/sostenibilidad/ubicacion/index.md
+++ b/eventos/sostenibilidad/ubicacion/index.md
@@ -4,5 +4,5 @@ Al organizar un evento nacional o local, ten en cuenta los siguientes aspectos.
 
 Favorece ciudades que tengan:
 - Excelentes conexiones de viaje de larga distancia con bajas emisiones de carbono (como los trenes).
-- Transporte público eficiente, fiable y accesible (consulta [la sección de viajes](https://es.wordpress.org/make/handbook/sostenibilidad/eventos/viajes) para más información).
+- Transporte público eficiente, fiable y accesible (consulta [la sección de viajes](https://es.wordpress.org/team/handbook/eventos/sostenibilidad/viajes/) para más información).
 - Políticas de sostenibilidad ambiental cuidadosamente implementadas.

--- a/eventos/sostenibilidad/viajes/index.md
+++ b/eventos/sostenibilidad/viajes/index.md
@@ -1,6 +1,6 @@
 # Viajes
 
-Una vez que hayas seleccionado [el lugar donde se celebrará el evento](https://es.wordpress.org/make/handbook/sostenibilidad/eventos/lugar), es hora de compartir la información con los asistentes y patrocinadores.
+Una vez que hayas seleccionado [el lugar donde se celebrará el evento](https://es.wordpress.org/team/handbook/eventos/sostenibilidad/lugar/), es hora de compartir la información con los asistentes y patrocinadores.
 
 Crea una página de «Cómo llegar»:
 - Fomenta los viajes en tren, bus o coche compartido por encima de los vuelos.


### PR DESCRIPTION
4 páginas de la sección «Eventos más sostenibles» tenían algunos enlaces que no funcionaban, los he corregido sustituyéndolos con la url correcta. ¡Gracias! 